### PR TITLE
Fix minor grammatical and reference issues

### DIFF
--- a/_posts/2010-04-23-orgs.markdown
+++ b/_posts/2010-04-23-orgs.markdown
@@ -85,7 +85,7 @@ You can get all the public organizations that a user is part of:
       ]
     }
 
-You can get fetch a list of all of your organizations:
+You can get a list of all of your organizations:
 
     /organizations [GET]
 


### PR DESCRIPTION
Three issues:
- Repetitive wording ('get fetch') for `/organizations` description.
- `/organizations/repositories` description very slightly misleading.
- Reference to repository's public members endpoint specifies `public_repositories` where it should be `public_members`.
