### PR TITLE
Fixed link to develop.github.com source code.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,7 +55,7 @@
         </div>
       </div>
       <div class="fork span-7">
-        This website is <a href="http://github.com/develop/develop.github.com">open source</a>.
+        This website is <a href="http://github.com/github/develop.github.com">open source</a>.
         Please help us by forking the project and adding to it.
       </div>
     </div>


### PR DESCRIPTION
The footer link was broken, but now it is fixed!
