### PR TITLE
Fix curl to update organization fields: -X PUT was missing

### DIFF
--- a/_posts/2010-04-23-orgs.markdown
+++ b/_posts/2010-04-23-orgs.markdown
@@ -45,14 +45,14 @@ Owners can update the organization with these fields:
 
     /organizations/:org [PUT]
 
-You can send POST params:
+You can send PUT params:
 
-    $ curl -d "organization[name]=New%20Name" \
+    $ curl -X PUT -d "organization[name]=New%20Name" \
       https://github.com/api/v2/json/organizations/github
 
 You can also send JSON:
 
-    $ curl -H "Content-Type: application/json"    \
+    $ curl -X PUT -H "Content-Type: application/json"    \
       -d '{"organization": {"name": "New Name"}}' \
       https://github.com/api/v2/json/organizations/github
 


### PR DESCRIPTION
Hello!
In order to update a field of an Organization (e.g., changing the location or the blog) it is necessary to indicate PUT. This was already documented (line 46 of 2010-04-23-orgs.markdown), however it was omitted in the `curl` examples, which I have fixed with this commit.
