### PR TITLE
Updated format of the response for a single pull request.

### DIFF
--- a/_posts/2010-04-23-pulls.markdown
+++ b/_posts/2010-04-23-pulls.markdown
@@ -47,41 +47,39 @@ repository is private, supply your login credentials.
 <pre class="terminal">
 $ curl http://github.com/api/v2/json/pulls/technoweenie/faraday
 {
-  "pulls": [
-    {
-      "state": "open",
-      "base": {
-        "label": "technoweenie:master",
-        "ref": "master",
-        "sha": "53397635da83a2f4b5e862b5e59cc66f6c39f9c6",
-        "user": {...},
-        "repository": {...}
-      },
-      "head": {
-        "label": "smparkes:synchrony",
-        "ref": "synchrony",
-        "sha": "83306eef49667549efebb880096cb539bd436560",
-        "user": {...},
-        "repository": {...}
-      },
-      "issue_user": {...},
+  "pull": {
+    "state": "open",
+    "base": {
+      "label": "technoweenie:master",
+      "ref": "master",
+      "sha": "53397635da83a2f4b5e862b5e59cc66f6c39f9c6",
       "user": {...},
-      "title": "Synchrony",
-      "body": "Here's the pull request.\r\n\r\nThis isn't generic EM: require's Ilya's synchrony and needs to be run on its own fiber, e.g., via synchrony or rack-fiberpool.\r\n\r\nI thought about a \"first class\" em adapter, but I think the faraday api is sync right now, right? Interesting idea to add something like rack's async support to faraday, but that's an itch I don't have right now.",
-      "position": 4.0,
-      "number": 15,
-      "votes": 0,
-      "comments": 4,
-      "diff_url": "https://github.com/technoweenie/faraday/pull/15.diff",
-      "patch_url": "https://github.com/technoweenie/faraday/pull/15.patch",
-      "labels": [],
-      "html_url": "https://github.com/technoweenie/faraday/pull/15",
-      "issue_created_at": "2010-10-04T12:39:18-07:00",
-      "issue_updated_at": "2010-11-04T16:35:04-07:00",
-      "created_at": "2010-10-04T12:39:18-07:00",
-      "updated_at": "2010-11-04T16:30:14-07:00"
-    }
-  ]
+      "repository": {...}
+    },
+    "head": {
+      "label": "smparkes:synchrony",
+      "ref": "synchrony",
+      "sha": "83306eef49667549efebb880096cb539bd436560",
+      "user": {...},
+      "repository": {...}
+    },
+    "issue_user": {...},
+    "user": {...},
+    "title": "Synchrony",
+    "body": "Here's the pull request.\r\n\r\nThis isn't generic EM: require's Ilya's synchrony and needs to be run on its own fiber, e.g., via synchrony or rack-fiberpool.\r\n\r\nI thought about a \"first class\" em adapter, but I think the faraday api is sync right now, right? Interesting idea to add something like rack's async support to faraday, but that's an itch I don't have right now.",
+    "position": 4.0,
+    "number": 15,
+    "votes": 0,
+    "comments": 4,
+    "diff_url": "https://github.com/technoweenie/faraday/pull/15.diff",
+    "patch_url": "https://github.com/technoweenie/faraday/pull/15.patch",
+    "labels": [],
+    "html_url": "https://github.com/technoweenie/faraday/pull/15",
+    "issue_created_at": "2010-10-04T12:39:18-07:00",
+    "issue_updated_at": "2010-11-04T16:35:04-07:00",
+    "created_at": "2010-10-04T12:39:18-07:00",
+    "updated_at": "2010-11-04T16:30:14-07:00"
+  }
 }
 </pre>
 
@@ -189,3 +187,4 @@ Pull Requests themselves don't update, they merely track changes to Issues and
 Commits.  See the [Issues API](/p/issues.html) for info on commenting on or
 closing Pull Requests.  Issues and Pull Requests use the same identification
 numbers.
+


### PR DESCRIPTION
The current page has the API response wrong, in that it shows the the `pulls` key being returned with a single pull. That's not how it works for real.
