### PR TITLE
Use ':number' instead of ':id' in 'Comment on issues' api

### DIFF
--- a/_posts/2010-04-23-issues.markdown
+++ b/_posts/2010-04-23-issues.markdown
@@ -247,7 +247,7 @@ a label from all issues.
 
 You can comment on issues at
 
-    /issues/comment/:user/:repo/:id
+    /issues/comment/:user/:repo/:number
 
 Simply send it a 'comment' POST variable with the comment you'd like to make.  It will attribute the comment to the user that is authenticated.  Here is an example:
 


### PR DESCRIPTION
All the other 'Comment on issues' api urls use :number to mean 'issue number', but the last url used :id. I thought this should be consistent.
